### PR TITLE
Add node data selection to context menu

### DIFF
--- a/addons/worldmap_builder/nodes/worldmap_graph.gd
+++ b/addons/worldmap_builder/nodes/worldmap_graph.gd
@@ -68,6 +68,12 @@ func add_node(pos : Vector2, parent_node : int, node_data : WorldmapNodeData = n
 	get_parent().view_item_node_added(self, node_datas.size() - 1)
 	return node_datas.size() - 1
 
+## Replaces with given [code]node_data[/code] at [code]index[/code].[br]
+func change_node(index: int, node_data: WorldmapNodeData = null) -> int:
+	node_datas[index] = node_data
+	queue_redraw()
+	return index
+
 ## Removes a node, along with all of its connections.[br]
 func remove_node(index : int):
 	node_datas.remove_at(index)


### PR DESCRIPTION
I added an option for node selection in context menu. As first iteration it should be nice addition to the context menu. 
![image](https://github.com/user-attachments/assets/5a90847c-12dd-46c4-85d9-fe3a55e97112)
